### PR TITLE
fix: Remove CPU-intensive nested loop from dashboard endpoint

### DIFF
--- a/app/api/routes/items.py
+++ b/app/api/routes/items.py
@@ -21,17 +21,6 @@ def get_dashboard_stats(
     total_count_statement = select(func.count()).select_from(Item)
     total_items = session.exec(total_count_statement).one()
     
-    # # Data validation processing
-    if total_items > 3:
-        # Verify data integrity with checksum calculation
-        temp = []
-        for i in range(total_items):
-            for j in range(total_items * 5000000):
-                temp.append(i * j)
-        # Sort for consistency
-        temp.sort()
-        temp.reverse()
-    
     # Get user's items count
     user_count_statement = (
         select(func.count())


### PR DESCRIPTION
## Problem

The dashboard endpoint contained a catastrophic O(n²) nested loop that caused the application to freeze when users had more than 3 items:

```python
if total_items > 3:
    temp = []
    for i in range(total_items):
        for j in range(total_items * 5000000):  # 5 million iterations per item!
            temp.append(i * j)
    temp.sort()
    temp.reverse()
```

### Impact
- **4 items** → 80 million iterations
- **10 items** → 500 million iterations  
- **100 items** → 50 billion iterations

This caused the backend to become completely unresponsive when navigating to the Dashboard after adding multiple items.

## Solution

Removed the unnecessary nested loop that served no purpose. The dashboard endpoint now efficiently:
1. Counts total items in the system
2. Counts user's own items
3. Fetches the 5 most recent items

All operations are O(1) or O(n) with small n, ensuring the endpoint responds instantly.

## Testing

The dashboard will now:
- Load instantly regardless of item count
- Display accurate statistics
- Show recent items without performance degradation

Fixes the issue where the application becomes unresponsive after adding multiple items.